### PR TITLE
Issue #8: Check if variables are empty before using them.

### DIFF
--- a/esign_webform/esign_webform.module
+++ b/esign_webform/esign_webform.module
@@ -113,8 +113,8 @@ function _webform_render_esign($component, $value = NULL, $filter = TRUE) {
 
   if (isset($value)) {
     $form_item['#default_value'] = array(
-      'signer_name' => $value['signer_name'],
-      'signer_title' => $value['signer_title'],
+      'signer_name' => $value['signer_name'] ?? '',
+      'signer_title' => $value['signer_title'] ?? '',
       'esignature' => $value['esignature'],
     );
   }


### PR DESCRIPTION
Fixes #8

This adds a check for an empty value before setting it.

This should be compatible with PHP 7.0 or later, but if you want compatibility with older PHP versions, I can make that change.
